### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Follow the steps below to build ReVanced Manager downloader template:
 > gpr.key = key
 > ```
 
-## 📜 Licence
+## 📜 License
 
 This project is licensed under the GPLv3 licence.
 Please see the [license file](LICENSE) for more information.


### PR DESCRIPTION
This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!