### PR TITLE
Use Charm instead of APK Mirror. 

### DIFF
--- a/src/main/kotlin/app/revanced/manager/downloaders/charm/CharmDownloader.kt
+++ b/src/main/kotlin/app/revanced/manager/downloaders/charm/CharmDownloader.kt
@@ -1,26 +1,28 @@
 @file:Suppress("Unused")
 
-package app.revanced.manager.downloaders.apkmirror
+package app.revanced.manager.downloaders.charm
 
-import android.net.Uri
 import app.revanced.manager.downloader.DownloadUrl
 import app.revanced.manager.downloader.Downloader
 import app.revanced.manager.downloader.download
 import app.revanced.manager.downloader.webview.runWebView
+
 import app.revanced.manager.downloaders.R
 import app.revanced.manager.downloaders.shared.Merger
-import java.net.URI
+
 import java.nio.file.Files
 import java.util.UUID
 import java.util.zip.ZipFile
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.deleteRecursively
+import kotlin.io.path.inputStream
 import kotlin.io.path.outputStream
 
 @OptIn(ExperimentalPathApi::class)
-val ApkMirrorDownloader = Downloader(R.string.apkmirror) {
+val CharmDownloader = Downloader(R.string.charm) {
+
     get { packageName, version ->
-        runWebView("APKMirror") {
+        runWebView("Charm") {
             download { url, _, userAgent ->
                 finish(
                     DownloadUrl(
@@ -29,46 +31,54 @@ val ApkMirrorDownloader = Downloader(R.string.apkmirror) {
                     )
                 )
             }
-
-            Uri.Builder()
-                .scheme("https")
-                .authority("www.apkmirror.com")
-                .appendQueryParameter("post_type", "app_release")
-                .appendQueryParameter("searchtype", "apk")
-                .appendQueryParameter("s", version?.let { "$packageName $it" } ?: packageName)
-                .appendQueryParameter("bundles%5B%5D" /* bundles[] */, "apk_files")
-                .toString()
+            "https://charm-cat.github.io/#$packageName"
         } to version
     }
 
     download { downloadUrl, outputStream ->
-        val workingDir = Files.createTempDirectory("apkmirror_dl")
+        val workingDir = Files.createTempDirectory("charm_dl")
         try {
-            if (URI(downloadUrl.url).path.substringAfterLast('/').endsWith(".apk")) {
-                val (inputStream, size) = downloadUrl.toDownloadResult()
-                inputStream.use {
+            val downloadedFile = workingDir.resolve(UUID.randomUUID().toString())
+            val (inputStream, size) = downloadUrl.toDownloadResult()
+
+            downloadedFile.outputStream().use { output ->
+                inputStream.use { stream ->
                     if (size != null) reportSize(size)
-                    it.copyTo(outputStream)
+                    stream.copyTo(output, bufferSize = 64 * 1024)
                 }
-            } else {
-                val downloadedFile = workingDir.resolve(UUID.randomUUID().toString()).also {
-                    it.outputStream().use { output ->
-                        downloadUrl.toDownloadResult().first.copyTo(output)
-                    }
+            }
+
+            var isBundle = false
+            try {
+                ZipFile(downloadedFile.toFile()).use { zip ->
+                    isBundle = zip.entries().asSequence().any { it.name.endsWith(".apk") }
                 }
+            } catch (e: Exception) {
+            }
+
+            if (isBundle) {
                 val xapkWorkingDir = workingDir.resolve("xapk").also { it.toFile().mkdirs() }
 
-                ZipFile(downloadedFile.toString()).use { zip ->
+                ZipFile(downloadedFile.toFile()).use { zip ->
                     zip.entries().asSequence().forEach { entry ->
-                        xapkWorkingDir.resolve(entry.name).also { it.parent.toFile().mkdirs() }.also { outputFile ->
+                        if (!entry.isDirectory) {
+                            val outputFile = xapkWorkingDir.resolve(entry.name)
+                            
+                            outputFile.parent.toFile().mkdirs()
+
                             zip.getInputStream(entry).use { input ->
                                 Files.copy(input, outputFile)
                             }
                         }
                     }
                 }
-
+                
                 Merger.merge(xapkWorkingDir).writeApk(outputStream)
+
+            } else {
+                downloadedFile.inputStream().use { stream ->
+                    stream.copyTo(outputStream, bufferSize = 64 * 1024)
+                }
             }
         } finally {
             workingDir.deleteRecursively()

--- a/src/main/kotlin/app/revanced/manager/downloaders/charm/CharmDownloader.kt
+++ b/src/main/kotlin/app/revanced/manager/downloaders/charm/CharmDownloader.kt
@@ -51,7 +51,7 @@ val CharmDownloader = Downloader(R.string.charm) {
             var isBundle = false
             try {
                 ZipFile(downloadedFile.toFile()).use { zip ->
-                    isBundle = zip.entries().asSequence().any { it.name.endsWith(".apk") }
+                    isBundle = zip.getEntry("AndroidManifest.xml") == null
                 }
             } catch (e: Exception) {
             }
@@ -61,7 +61,7 @@ val CharmDownloader = Downloader(R.string.charm) {
 
                 ZipFile(downloadedFile.toFile()).use { zip ->
                     zip.entries().asSequence().forEach { entry ->
-                        if (!entry.isDirectory) {
+                        if (!entry.isDirectory && entry.name.endsWith(".apk")) {
                             val outputFile = xapkWorkingDir.resolve(entry.name)
                             
                             outputFile.parent.toFile().mkdirs()

--- a/src/main/res/values/arrays.xml
+++ b/src/main/res/values/arrays.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="app.revanced.manager.downloader.classes">
-        <item>app.revanced.manager.downloaders.apkmirror.APKMirrorDownloaderKt</item>
+        <item>app.revanced.manager.downloaders.charm.CharmDownloaderKt</item>
         <!--
         Play store login is currently broken. Disabling it for now.
         <item>app.revanced.manager.downloaders.play.store.PlayStoreDownloaderKt</item>

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
     <string name="app_name">ReVanced Manager: Downloaders</string>
-    <string name="apkmirror">APKMirror</string>
+    <string name="charm">Charm</string>
     <string name="play_store">Play Store</string>
 </resources>


### PR DESCRIPTION
!!! CHECK THE CODE BEFORE PR, IT GIVES ERROR FOR SOME REASON !!!

I created https://charm-cat.github.io as an alternative for APK Mirror/Pure to make downloading APK files easier for everyone. 
Charm does not have ads and it is completely free and open source, and also has APK files that is missing from APK Mirror.
Files are being hosted on buzzheavier.com I have contacted with the owner of buzzheavier for the files to not expire and for no ads on the download pages and they allowed it for my project. 
I am also planning to upload apk files to sourceforge too.
Downloading APK files from Charm is about 15 seconds faster than APK Mirror on average. 

Charm website: https://charm-cat.github.io/
Website repo: https://github.com/charm-cat/charm-cat.github.io
Charm downloader: https://github.com/charm-cat/charm-downloaders

Please check the code for the changes I have made for this pull request since it does not work but the charm downloader does work without a problem.
If I try to use the downloader (with the code from this pr) ReVanced gives  "No downloader with name" error.
I fixed this problem on Charm downloader by changing `val packageName = "app.revanced.manager.downloaders"` to `val packageName = "cat.charm.downloaders"` in "build.gradle.kts". 
I do not understand why this is happening since this change was not necessary for APK Mirror.

See the screenshot of the error:

![revanced-error](https://github.com/user-attachments/assets/5fa906d7-db96-4f35-8c8c-538526715dcb)